### PR TITLE
Guard DOM access

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -22,8 +22,10 @@ const Contact = () => {
     const subject = `Portfolio Contact: Message from ${formData.name}`;
     const body = `Name: ${formData.name}\nEmail: ${formData.email}\n\nMessage:\n${formData.message}`;
     const mailtoLink = `mailto:contact@dasunsucharith.me?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
-    
-    window.location.href = mailtoLink;
+
+    if (typeof window !== 'undefined') {
+      window.location.href = mailtoLink;
+    }
     
     toast({
       title: "Email client opened!",

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -4,6 +4,8 @@ import { ArrowDown, Github, Linkedin, Mail } from 'lucide-react';
 
 const Hero = () => {
   const scrollToSection = (sectionId: string) => {
+    if (typeof document === 'undefined') return;
+
     const element = document.getElementById(sectionId);
     if (element) {
       element.scrollIntoView({ behavior: 'smooth' });

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -6,6 +6,8 @@ const Navigation = () => {
   const [isScrolled, setIsScrolled] = useState(false);
 
   useEffect(() => {
+    if (typeof window === 'undefined') return;
+
     const handleScroll = () => {
       setIsScrolled(window.scrollY > 50);
     };
@@ -15,6 +17,8 @@ const Navigation = () => {
   }, []);
 
   const scrollToSection = (sectionId: string) => {
+    if (typeof document === 'undefined') return;
+
     const element = document.getElementById(sectionId);
     if (element) {
       element.scrollIntoView({ behavior: 'smooth' });

--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -6,12 +6,16 @@ export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
 
   React.useEffect(() => {
+    if (typeof window === "undefined") return
+
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
     const onChange = () => {
       setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
     }
+
     mql.addEventListener("change", onChange)
     setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+
     return () => mql.removeEventListener("change", onChange)
   }, [])
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,5 +1,6 @@
 
-import Navigation from '@/components/Navigation';
+import { Suspense, lazy } from 'react';
+const Navigation = lazy(() => import('@/components/Navigation'));
 import Hero from '@/components/Hero';
 import About from '@/components/About';
 import Projects from '@/components/Projects';
@@ -9,7 +10,9 @@ import Footer from '@/components/Footer';
 const Index = () => {
   return (
     <div className="min-h-screen">
-      <Navigation />
+      <Suspense fallback={null}>
+        <Navigation />
+      </Suspense>
       <Hero />
       <About />
       <Projects />


### PR DESCRIPTION
## Summary
- avoid DOM usage on the server by checking `window` and `document`
- dynamically import `Navigation`

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684129f61e748320847f83d954fd81b8